### PR TITLE
hosted workflows in Dockstore

### DIFF
--- a/jupyter-notebooks/tutorials/data/dockstore_publish/Dockstore.cwl
+++ b/jupyter-notebooks/tutorials/data/dockstore_publish/Dockstore.cwl
@@ -1,0 +1,14 @@
+cwlVersion: v1.0
+
+class: Workflow
+doc: |
+    Bogus hosted workflow registered by unity_py.
+
+steps:
+step:
+    run: step.cwl
+
+s:author:
+  - class: s:Person
+    s:email: mliukis@jpl.nasa.gov
+    s:name: Masha Liukis

--- a/jupyter-notebooks/tutorials/data/dockstore_publish/parameters.json
+++ b/jupyter-notebooks/tutorials/data/dockstore_publish/parameters.json
@@ -1,0 +1,68 @@
+{
+    "processDescription": {
+        "process": {
+            "id": "unity-example-application..HEAD",
+            "title": "Add missing import",
+            "owsContext": {
+                "offering": {
+                    "content": {
+                        "href": "https://raw.githubusercontent.com/jplzhan/artifact-deposit-repo/main/unity-example-application//HEAD/workflow.cwl"
+                    }
+                }
+            },
+            "abstract": "Application Package Demo",
+            "keywords": [
+                "Demo"
+            ],
+            "inputs": [
+                {
+                    "id": "line_offset",
+                    "title": "Automatically detected using papermill.",
+                    "literalDataDomains": [
+                        {
+                            "dataType": {
+                                "name": "float"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "output_directory",
+                    "title": "Automatically detected using papermill.",
+                    "literalDataDomains": [
+                        {
+                            "dataType": {
+                                "name": "string"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "input_filename",
+                    "title": "Stage-in input specified for URL-to-PATH conversion.",
+                    "literalDataDomains": [
+                        {
+                            "dataType": {
+                                "name": "stage_in"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "outputs": []
+        },
+        "processVersion": "1.0.0",
+        "jobControlOptions": [
+            "async-execute"
+        ],
+        "outputTransmission": [
+            "reference"
+        ]
+    },
+    "immediateDeployment": true,
+    "executionUnit": [
+        {
+            "href": "docker://unity-example-application.head"
+        }
+    ]
+}

--- a/jupyter-notebooks/tutorials/data/dockstore_publish/step.cwl
+++ b/jupyter-notebooks/tutorials/data/dockstore_publish/step.cwl
@@ -1,0 +1,5 @@
+cwlVersion: v1.0
+
+class: Workflow
+doc: |
+    Additional CWL file for the bogus hosted workflow registered by unity_py.

--- a/jupyter-notebooks/tutorials/data/dockstore_update/Dockstore.cwl
+++ b/jupyter-notebooks/tutorials/data/dockstore_update/Dockstore.cwl
@@ -1,0 +1,15 @@
+# ML: Update
+cwlVersion: v1.0
+
+class: Workflow
+doc: |
+    Bogus hosted workflow registered by unity_py.
+
+steps:
+step:
+    run: step.cwl
+
+s:author:
+  - class: s:Person
+    s:email: mliukis@jpl.nasa.gov
+    s:name: Masha Liukis

--- a/jupyter-notebooks/tutorials/data/dockstore_update/parameters.json
+++ b/jupyter-notebooks/tutorials/data/dockstore_update/parameters.json
@@ -1,0 +1,67 @@
+{
+    "processDescription": {
+        "process": {
+            "id": "unity-example-application..HEAD",
+            "title": "Add missing import",
+            "owsContext": {
+                "offering": {
+                    "content": {
+                        "href": "https://raw.githubusercontent.com/jplzhan/artifact-deposit-repo/main/unity-example-application//HEAD/workflow.cwl"
+                    }
+                }
+            },
+            "abstract": "Application Package Demo",
+            "keywords": [
+                "Demo"
+            ],
+            "inputs": [
+                {
+                    "id": "line_offset",
+                    "title": "Automatically detected using papermill.",
+                    "literalDataDomains": [
+                        {
+                            "dataType": {
+                                "name": "float"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "output_directory",
+                    "title": "Automatically detected using papermill.",
+                    "literalDataDomains": [
+                        {
+                            "dataType": {
+                                "name": "string"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "input_filename",
+                    "title": "Stage-in input specified for URL-to-PATH conversion.",
+                    "literalDataDomains": [
+                        {
+                            "dataType": {
+                                "name": "stage_in"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "processVersion": "1.0.0",
+        "jobControlOptions": [
+            "async-execute"
+        ],
+        "outputTransmission": [
+            "reference"
+        ]
+    },
+    "immediateDeployment": true,
+    "executionUnit": [
+        {
+            "href": "docker://unity-example-application.head"
+        }
+    ]
+}

--- a/jupyter-notebooks/tutorials/dockstore_publish.ipynb
+++ b/jupyter-notebooks/tutorials/dockstore_publish.ipynb
@@ -47,9 +47,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# \"test\" deployment of the Dockstore:\n",
     "# dockstore_api_uri = \"http://uads-test-dockstore-deploy-lb-1762603872.us-west-2.elb.amazonaws.com:9998/api\"\n",
     "\n",
-    "# \"Dev\" deployment of the Dockstore:\n",
+    "# \"dev\" deployment of the Dockstore:\n",
     "dockstore_api_uri = \"http://awslbdockstorestack-lb-1205958675.us-west-2.elb.amazonaws.com:9998/api\""
    ]
   },
@@ -115,7 +116,10 @@
       "13 hosted_workflow_CWL_JSON git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow_CWL_JSON.git\n",
       "14 hosted_workflow_upload git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow_upload.git\n",
       "15 hosted_workflow_test git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow_test.git\n",
-      "16 published_hosted_workflow git@dockstore.org:workflows/dockstore.org/mliukis/published_hosted_workflow.git\n"
+      "16 published_hosted_workflow git@dockstore.org:workflows/dockstore.org/mliukis/published_hosted_workflow.git\n",
+      "17 hosted_workflow_by_name git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow_by_name.git\n",
+      "18 workflow_by_unity_py git@dockstore.org:workflows/dockstore.org/mliukis/workflow_by_unity_py.git\n",
+      "19 workflow_by_unity git@dockstore.org:workflows/dockstore.org/mliukis/workflow_by_unity.git\n"
      ]
     }
    ],
@@ -129,12 +133,12 @@
    "id": "9094f83c-4671-420e-92e2-85d03facf277",
    "metadata": {},
    "source": [
-    "## Existing User Published Applications"
+    "## Existing Published User Applications"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 8,
    "id": "8a8e5b2b-1fe7-4a57-85e2-8e5337b8b447",
    "metadata": {},
    "outputs": [
@@ -147,7 +151,8 @@
       "8 test_hosted_workflow_from_python git@dockstore.org:workflows/dockstore.org/mliukis/test_hosted_workflow_from_python.git\n",
       "12 hosted_workflow git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow.git\n",
       "15 hosted_workflow_test git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow_test.git\n",
-      "17 hosted_workflow_by_name git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow_by_name.git\n"
+      "17 hosted_workflow_by_name git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow_by_name.git\n",
+      "19 workflow_by_unity git@dockstore.org:workflows/dockstore.org/mliukis/workflow_by_unity.git\n"
      ]
     }
    ],
@@ -161,7 +166,7 @@
    "id": "c4d10706-f649-4e16-b253-48b81d2db847",
    "metadata": {},
    "source": [
-    "## All Existing Published Applications"
+    "## Existing Published Applications for All Users"
    ]
   },
   {
@@ -174,6 +179,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "19 workflow_by_unity git@dockstore.org:workflows/dockstore.org/mliukis/workflow_by_unity.git\n",
+      "17 hosted_workflow_by_name git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow_by_name.git\n",
       "15 hosted_workflow_test git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow_test.git\n",
       "12 hosted_workflow git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow.git\n",
       "8 test_hosted_workflow_from_python git@dockstore.org:workflows/dockstore.org/mliukis/test_hosted_workflow_from_python.git\n",
@@ -194,25 +201,17 @@
    "id": "29b1516d-e67e-48d7-a2fc-e4293317f46a",
    "metadata": {},
    "source": [
-    "## Create New Application"
+    "## Create and Publish New Application in Dockstore"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "id": "fcbe7a9c-6893-424d-822a-f1c1a1b10773",
    "metadata": {},
    "outputs": [],
    "source": [
-    "name = \"hosted_workflow_by_name\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1f94da3e-727a-456e-ab13-32edf688ddba",
-   "metadata": {},
-   "source": [
-    "## Create and Publish New Application in Dockstore"
+    "name = \"workflow\""
    ]
   },
   {
@@ -222,53 +221,51 @@
    "source": [
     "### Parameter Files to Upload to Dockstore\n",
     "\n",
-    "Dockstore hard-codes the path for primary descriptor file of the hosted workflow to **Dockstore.cwl**, so we must use that filename when uploading the file to the Dockstore."
+    "NOTE: Dockstore hard-codes the path for primary descriptor file of the hosted workflow to **Dockstore.cwl**, so we must use that filename when uploading primary CWL parameter file to the Dockstore.\n",
+    "\n",
+    "**DockstoreAppCatalog** uploads all parameter files for the application at the same time (by the same URL request) when new application is registered within the Dockstore. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "9b2ea3d8-9dd6-4d42-9346-1e9298d8e2f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cwl_param_files = [\n",
+    "    'data/dockstore_publish/Dockstore.cwl',\n",
+    "    'data/dockstore_publish/step.cwl'\n",
+    "]\n",
+    "\n",
+    "json_param_files = [\n",
+    "    'data/dockstore_publish/parameters.json'\n",
+    "]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "9b2ea3d8-9dd6-4d42-9346-1e9298d8e2f5",
+   "id": "f3ea1bb2-00ff-46d6-9a18-ef23a5bd93f0",
    "metadata": {},
    "outputs": [],
    "source": [
-    "parameter_file_dir = 'data/dockstore_publish'\n",
-    "\n",
-    "cwl_param_files = ['Dockstore.cwl', 'step.cwl']\n",
-    "json_param_files = ['parameters.json']"
+    "reg_app = app_catalog.register(app_name=name, cwl_files=cwl_param_files, json_files=json_param_files, publish=True)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "f3ea1bb2-00ff-46d6-9a18-ef23a5bd93f0",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Publishing the workflow\n"
-     ]
-    }
-   ],
-   "source": [
-    "reg_app = app_catalog.register(name, cwl_files=cwl_param_files, json_files=json_param_files, cwd=parameter_file_dir, publish=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
    "id": "360a929a-bbbf-4a51-8433-b72f7424f7b7",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "DockstoreApplicationPackage(name='hosted_workflow_by_name', source_repository='git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow_by_name.git', workflow_path='/Dockstore.cwl', id='17', is_published=True, description='Bogus hosted workflow registered by unity_py.\\n', workflow_type='CWL', dockstore_info={'type': 'BioWorkflow', 'descriptorType': 'CWL', 'aliases': {}, 'author': 'Masha Liukis', 'checker_id': None, 'conceptDoi': None, 'dbCreateDate': 1681166040783, 'dbUpdateDate': 1681166041216, 'defaultTestParameterFilePath': '/test.json', 'defaultVersion': '1', 'description': 'Bogus hosted workflow registered by unity_py.\\n', 'descriptorTypeSubclass': 'NOT_APPLICABLE', 'email': 'mliukis@jpl.nasa.gov', 'forumUrl': None, 'full_workflow_path': 'dockstore.org/mliukis/hosted_workflow_by_name', 'gitUrl': 'git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow_by_name.git', 'has_checker': False, 'id': 17, 'input_file_formats': [], 'isChecker': False, 'is_published': True, 'labels': [], 'lastUpdated': 1681166040780, 'last_modified': 1833828200, 'last_modified_date': 1681166040936, 'licenseInformation': {'licenseName': None}, 'mode': 'HOSTED', 'organization': 'mliukis', 'output_file_formats': [], 'parent_id': None, 'path': 'dockstore.org/mliukis/hosted_workflow_by_name', 'repository': 'hosted_workflow_by_name', 'sourceControl': 'dockstore.org', 'source_control_provider': 'DOCKSTORE', 'starredUsers': [], 'topic': None, 'topicAutomatic': None, 'topicId': None, 'topicManual': None, 'topicSelection': 'AUTOMATIC', 'userIdToOrcidPutCode': None, 'users': [{'avatarUrl': 'https://avatars.githubusercontent.com/u/72407733?v=4', 'curator': True, 'id': 2, 'isAdmin': True, 'name': 'mliukis', 'orcid': None, 'privacyPolicyVersion': 'PRIVACY_POLICY_VERSION_2_5', 'privacyPolicyVersionAcceptanceDate': 1676409759024, 'setupComplete': False, 'tosacceptanceDate': 1676409759024, 'tosversion': 'TOS_VERSION_2', 'userProfiles': None, 'username': 'mliukis', 'usernameChangeRequired': False}], 'workflowName': None, 'workflowVersions': [{'aliases': None, 'author': 'Masha Liukis', 'authors': [{'affiliation': None, 'email': 'mliukis@jpl.nasa.gov', 'name': 'Masha Liukis', 'role': None}], 'commitID': None, 'dbUpdateDate': 1681166040964, 'description': 'Bogus hosted workflow registered by unity_py.\\n', 'descriptionSource': 'DESCRIPTOR', 'dirtyBit': False, 'doiStatus': 'NOT_REQUESTED', 'doiURL': None, 'email': 'mliukis@jpl.nasa.gov', 'frozen': False, 'hidden': False, 'id': 15, 'images': None, 'input_file_formats': [], 'last_modified': 1681166040936, 'legacyVersion': True, 'name': '1', 'orcidAuthors': None, 'output_file_formats': [], 'reference': None, 'referenceType': 'TAG', 'subClass': None, 'synced': False, 'valid': True, 'validations': None, 'verified': False, 'verifiedSource': None, 'verifiedSources': [], 'versionEditor': {'avatarUrl': 'https://avatars.githubusercontent.com/u/72407733?v=4', 'curator': True, 'id': 2, 'isAdmin': True, 'name': 'mliukis', 'orcid': None, 'privacyPolicyVersion': 'PRIVACY_POLICY_VERSION_2_5', 'privacyPolicyVersionAcceptanceDate': 1676409759024, 'setupComplete': False, 'tosacceptanceDate': 1676409759024, 'tosversion': 'TOS_VERSION_2', 'userProfiles': None, 'username': 'mliukis', 'usernameChangeRequired': False}, 'versionMetadata': {'description': 'Bogus hosted workflow registered by unity_py.\\n', 'id': 15, 'parsedInformationSet': [], 'publicAccessibleTestParameterFile': None, 'userIdToOrcidPutCode': {}}, 'workflow_path': '/Dockstore.cwl', 'workingDirectory': ''}], 'workflow_path': '/Dockstore.cwl'})"
+       "DockstoreApplicationPackage(name='workflow', source_repository='git@dockstore.org:workflows/dockstore.org/mliukis/workflow.git', workflow_path='/Dockstore.cwl', id='20', is_published=True, description='Bogus hosted workflow registered by unity_py.\\n', workflow_type='CWL', dockstore_info={'type': 'BioWorkflow', 'descriptorType': 'CWL', 'aliases': {}, 'author': 'Masha Liukis', 'checker_id': None, 'conceptDoi': None, 'dbCreateDate': 1681261658271, 'dbUpdateDate': 1681261658667, 'defaultTestParameterFilePath': '/test.json', 'defaultVersion': '1', 'description': 'Bogus hosted workflow registered by unity_py.\\n', 'descriptorTypeSubclass': 'NOT_APPLICABLE', 'email': 'mliukis@jpl.nasa.gov', 'forumUrl': None, 'full_workflow_path': 'dockstore.org/mliukis/workflow', 'gitUrl': 'git@dockstore.org:workflows/dockstore.org/mliukis/workflow.git', 'has_checker': False, 'id': 20, 'input_file_formats': [], 'isChecker': False, 'is_published': True, 'labels': [], 'lastUpdated': 1681261658269, 'last_modified': 1929445688, 'last_modified_date': 1681261658424, 'licenseInformation': {'licenseName': None}, 'mode': 'HOSTED', 'organization': 'mliukis', 'output_file_formats': [], 'parent_id': None, 'path': 'dockstore.org/mliukis/workflow', 'repository': 'workflow', 'sourceControl': 'dockstore.org', 'source_control_provider': 'DOCKSTORE', 'starredUsers': [], 'topic': None, 'topicAutomatic': None, 'topicId': None, 'topicManual': None, 'topicSelection': 'AUTOMATIC', 'userIdToOrcidPutCode': None, 'users': [{'avatarUrl': 'https://avatars.githubusercontent.com/u/72407733?v=4', 'curator': True, 'id': 2, 'isAdmin': True, 'name': 'mliukis', 'orcid': None, 'privacyPolicyVersion': 'PRIVACY_POLICY_VERSION_2_5', 'privacyPolicyVersionAcceptanceDate': 1676409759024, 'setupComplete': False, 'tosacceptanceDate': 1676409759024, 'tosversion': 'TOS_VERSION_2', 'userProfiles': None, 'username': 'mliukis', 'usernameChangeRequired': False}], 'workflowName': None, 'workflowVersions': [{'aliases': None, 'author': 'Masha Liukis', 'authors': [{'affiliation': None, 'email': 'mliukis@jpl.nasa.gov', 'name': 'Masha Liukis', 'role': None}], 'commitID': None, 'dbUpdateDate': 1681261658447, 'description': 'Bogus hosted workflow registered by unity_py.\\n', 'descriptionSource': 'DESCRIPTOR', 'dirtyBit': False, 'doiStatus': 'NOT_REQUESTED', 'doiURL': None, 'email': 'mliukis@jpl.nasa.gov', 'frozen': False, 'hidden': False, 'id': 29, 'images': None, 'input_file_formats': [], 'last_modified': 1681261658424, 'legacyVersion': True, 'name': '1', 'orcidAuthors': None, 'output_file_formats': [], 'reference': None, 'referenceType': 'TAG', 'subClass': None, 'synced': False, 'valid': True, 'validations': None, 'verified': False, 'verifiedSource': None, 'verifiedSources': [], 'versionEditor': {'avatarUrl': 'https://avatars.githubusercontent.com/u/72407733?v=4', 'curator': True, 'id': 2, 'isAdmin': True, 'name': 'mliukis', 'orcid': None, 'privacyPolicyVersion': 'PRIVACY_POLICY_VERSION_2_5', 'privacyPolicyVersionAcceptanceDate': 1676409759024, 'setupComplete': False, 'tosacceptanceDate': 1676409759024, 'tosversion': 'TOS_VERSION_2', 'userProfiles': None, 'username': 'mliukis', 'usernameChangeRequired': False}, 'versionMetadata': {'description': 'Bogus hosted workflow registered by unity_py.\\n', 'id': 29, 'parsedInformationSet': [], 'publicAccessibleTestParameterFile': None, 'userIdToOrcidPutCode': {}}, 'workflow_path': '/Dockstore.cwl', 'workingDirectory': ''}], 'workflow_path': '/Dockstore.cwl'})"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -287,7 +284,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 14,
    "id": "0313f8f1-90a9-4c1c-b486-17f1d7b3edd9",
    "metadata": {},
    "outputs": [
@@ -299,7 +296,10 @@
       "2 sounder_sips_l1b git@github.com:mliukis/sounder-sips-application.git\n",
       "8 test_hosted_workflow_from_python git@dockstore.org:workflows/dockstore.org/mliukis/test_hosted_workflow_from_python.git\n",
       "12 hosted_workflow git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow.git\n",
-      "15 hosted_workflow_test git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow_test.git\n"
+      "15 hosted_workflow_test git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow_test.git\n",
+      "17 hosted_workflow_by_name git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow_by_name.git\n",
+      "19 workflow_by_unity git@dockstore.org:workflows/dockstore.org/mliukis/workflow_by_unity.git\n",
+      "20 workflow git@dockstore.org:workflows/dockstore.org/mliukis/workflow.git\n"
      ]
     }
    ],
@@ -313,9 +313,7 @@
    "id": "f95baacb-8821-4118-9a67-1789e0cb76a2",
    "metadata": {},
    "source": [
-    "## Or Upload Workflow's CWL and JSON Parameters Files One at a Time \n",
-    "\n",
-    "It's possible to upload all parameter files for the workflow at the same time, or upload one parameter file at a time."
+    "## Upload / Update Workflow's CWL and JSON Parameter Files One at a Time "
    ]
   },
   {
@@ -323,42 +321,29 @@
    "id": "9296ea97-a157-47eb-b189-d4ea2886afa5",
    "metadata": {},
    "source": [
-    "### Upload Primary Descriptor CWL File for the Application  "
+    "### Upload/Update CWL File for the Application\n",
+    "\n",
+    "**DockstoreAppCatalog** can upload parameter files one at a time, which might be useful when uploading updated parameter files for already registered application within the Dockstore."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "9308786c-f5bf-4e9b-b849-c843577bf7bc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Remember current path\n",
-    "cwd = os.getcwd()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 15,
    "id": "dc1d7793-d153-45ca-a247-cc8a78a60ed1",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Change directory to where updated files for the upload are\n",
-    "data_dir = 'data/dockstore_update'\n",
-    "os.chdir(data_dir)\n",
-    "\n",
-    "param_file = 'Dockstore.cwl'"
+    "param_file = 'data/dockstore_update/Dockstore.cwl'"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 16,
    "id": "bce63ff3-e76b-4b8d-a3cc-0c8e890bfaab",
    "metadata": {},
    "outputs": [],
    "source": [
-    "app_catalog.uploadParameterFile(reg_app, param_file)"
+    "app_catalog.upload_parameter_file(application=reg_app, param_filename=param_file)"
    ]
   },
   {
@@ -366,27 +351,27 @@
    "id": "feefb17e-4fd1-4ee0-bfcd-b2509381de1f",
    "metadata": {},
    "source": [
-    "### Upload JSON Parameter File for the Application"
+    "### Upload/Update JSON File for the Application"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 17,
    "id": "bb94dd6b-315c-4afb-b5b1-ee4f526a3451",
    "metadata": {},
    "outputs": [],
    "source": [
-    "json_param_file = 'parameters.json'"
+    "json_param_file = 'data/dockstore_update/parameters.json'"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 18,
    "id": "1168e7f6-6cfe-4edb-8b31-8340f875ece4",
    "metadata": {},
    "outputs": [],
    "source": [
-    "app_catalog.uploadJSONFile(reg_app, json_param_file)"
+    "app_catalog.upload_json_file(application=reg_app, param_filename=json_param_file)"
    ]
   },
   {
@@ -394,29 +379,60 @@
    "id": "38b501b2-eb5f-46e5-96df-9bb0563f440c",
    "metadata": {},
    "source": [
-    "### Remove parameter file from the workflow\n",
+    "### Remove Parameter File from the Application\n",
     "\n",
-    "To remove any of the uploaded files from the hosted workflow, please upload file with empty contents to the Dockstore."
+    "To remove any of the uploaded files from the hosted workflow, please upload file with empty contents to the Dockstore.\n",
+    "\n",
+    "Dockstore does not remove the file, but replaces it with pre-defined (by the Dockstore) template file."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 19,
    "id": "b779b2f9-87ab-4643-9843-bda8a9e3937d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "file_path = 'step.cwl'"
+    "file_path = 'data/dockstore_update/step.cwl'"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 20,
    "id": "d01e37fb-a3dd-49d4-b17d-8d576655d58e",
    "metadata": {},
    "outputs": [],
    "source": [
-    "app_catalog.uploadParameterFile(reg_app, file_path)"
+    "app_catalog.upload_parameter_file(application=reg_app, param_filename=file_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a54100a5-9fed-4188-aaaf-4c5be8bbfe74",
+   "metadata": {},
+   "source": [
+    "### Upload Parameter File to the Application with Provided Dockstore Filename"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "720ceb60-341a-40a9-a18e-00e9a5337e70",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_path = 'data/dockstore_publish/step.cwl'\n",
+    "dockstore_path = 'temp/test_step.cwl'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "926fbe2f-0f3e-4b75-961a-42c5f302d1dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app_catalog.upload_parameter_file(application=reg_app, param_filename=file_path, dockstore_filename=dockstore_path)"
    ]
   },
   {
@@ -428,17 +444,17 @@
    "source": [
     "## Unpublish Application\n",
     "\n",
-    "Dockstore does not allow to delete hosted workflows. "
+    "Dockstore does not allow to delete hosted workflows, so the application can only be unpublished."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 23,
    "id": "307ee2df-c596-4170-81bb-faff193c86b7",
    "metadata": {},
    "outputs": [],
    "source": [
-    "app_catalog.unpublish(reg_app)"
+    "app_catalog.unpublish(application=reg_app)"
    ]
   },
   {
@@ -451,7 +467,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 24,
    "id": "978beac7-6dec-4fce-88f4-47f1786c346d",
    "metadata": {},
    "outputs": [
@@ -463,7 +479,9 @@
       "2 sounder_sips_l1b git@github.com:mliukis/sounder-sips-application.git\n",
       "8 test_hosted_workflow_from_python git@dockstore.org:workflows/dockstore.org/mliukis/test_hosted_workflow_from_python.git\n",
       "12 hosted_workflow git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow.git\n",
-      "15 hosted_workflow_test git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow_test.git\n"
+      "15 hosted_workflow_test git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow_test.git\n",
+      "17 hosted_workflow_by_name git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow_by_name.git\n",
+      "19 workflow_by_unity git@dockstore.org:workflows/dockstore.org/mliukis/workflow_by_unity.git\n"
      ]
     }
    ],
@@ -474,40 +492,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
-   "id": "12075f02-209d-49d2-b622-f6c65ef8dd8e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Change directory back to original\n",
-    "os.chdir(cwd)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 36,
-   "id": "16e49db7-970e-447c-abd0-caa634ddaba6",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'/Users/mliukis/Documents/Unity/ADS/sounder-sips-tutorial/jupyter-notebooks/tutorials'"
-      ]
-     },
-     "execution_count": 36,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "os.getcwd()"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": null,
-   "id": "df8e476f-ad04-456f-ad26-26442d001975",
+   "id": "6c93a215-6d1f-4432-9f4b-967b69cbd6c8",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/jupyter-notebooks/tutorials/dockstore_publish.ipynb
+++ b/jupyter-notebooks/tutorials/dockstore_publish.ipynb
@@ -462,7 +462,7 @@
    "id": "08dac163-bc22-4cfd-a853-1a3eaba2e410",
    "metadata": {},
    "source": [
-    "## Verify Application Was Unpublished"
+    "### Verify Application is Unpublished"
    ]
   },
   {

--- a/jupyter-notebooks/tutorials/dockstore_publish.ipynb
+++ b/jupyter-notebooks/tutorials/dockstore_publish.ipynb
@@ -7,7 +7,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
+    "import os  \n",
     "import sys"
    ]
   },
@@ -18,7 +18,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sys.path.append(os.path.expanduser(\"~/unity-py\"))"
+    "# sys.path.append(os.path.expanduser(\"~/unity-py\"))\n",
+    "sys.path.append(os.path.expanduser(\"~/Documents/Unity/ADS/unity-py\"))"
    ]
   },
   {
@@ -46,7 +47,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dockstore_api_uri = \"http://uads-test-dockstore-deploy-lb-1762603872.us-west-2.elb.amazonaws.com:9998/api\""
+    "# dockstore_api_uri = \"http://uads-test-dockstore-deploy-lb-1762603872.us-west-2.elb.amazonaws.com:9998/api\"\n",
+    "\n",
+    "# \"Dev\" deployment of the Dockstore:\n",
+    "dockstore_api_uri = \"http://awslbdockstorestack-lb-1205958675.us-west-2.elb.amazonaws.com:9998/api\""
    ]
   },
   {
@@ -93,9 +97,95 @@
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 sounder_sips_l1a git@github.com:mliukis/sounder-sips-application.git\n",
+      "2 sounder_sips_l1b git@github.com:mliukis/sounder-sips-application.git\n",
+      "3 jpl-uads-test git@github.com:mliukis/unity-ads-dockstore-app-test.git\n",
+      "6 sounder_sips_l1a git@github.com:unity-sds/sounder-sips-application.git\n",
+      "7 test_hosted_fromUI git@dockstore.org:workflows/dockstore.org/mliukis/test_hosted_fromUI.git\n",
+      "8 test_hosted_workflow_from_python git@dockstore.org:workflows/dockstore.org/mliukis/test_hosted_workflow_from_python.git\n",
+      "9 test_hosted_fromUI_N1 git@dockstore.org:workflows/dockstore.org/mliukis/test_hosted_fromUI_N1.git\n",
+      "10 test_hosted_workflow_from_python_N2 git@dockstore.org:workflows/dockstore.org/mliukis/test_hosted_workflow_from_python_N2.git\n",
+      "11 test_hosted_workflow_from_python_N3 git@dockstore.org:workflows/dockstore.org/mliukis/test_hosted_workflow_from_python_N3.git\n",
+      "12 hosted_workflow git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow.git\n",
+      "13 hosted_workflow_CWL_JSON git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow_CWL_JSON.git\n",
+      "14 hosted_workflow_upload git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow_upload.git\n",
+      "15 hosted_workflow_test git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow_test.git\n",
+      "16 published_hosted_workflow git@dockstore.org:workflows/dockstore.org/mliukis/published_hosted_workflow.git\n"
+     ]
+    }
+   ],
    "source": [
     "for app in app_catalog.application_list(for_user=True):\n",
+    "    print(f\"{app.id} {app.name} {app.source_repository}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9094f83c-4671-420e-92e2-85d03facf277",
+   "metadata": {},
+   "source": [
+    "## Existing User Published Applications"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "8a8e5b2b-1fe7-4a57-85e2-8e5337b8b447",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 sounder_sips_l1a git@github.com:mliukis/sounder-sips-application.git\n",
+      "2 sounder_sips_l1b git@github.com:mliukis/sounder-sips-application.git\n",
+      "8 test_hosted_workflow_from_python git@dockstore.org:workflows/dockstore.org/mliukis/test_hosted_workflow_from_python.git\n",
+      "12 hosted_workflow git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow.git\n",
+      "15 hosted_workflow_test git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow_test.git\n",
+      "17 hosted_workflow_by_name git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow_by_name.git\n"
+     ]
+    }
+   ],
+   "source": [
+    "for app in app_catalog.application_list(for_user=True, published=True):\n",
+    "    print(f\"{app.id} {app.name} {app.source_repository}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4d10706-f649-4e16-b253-48b81d2db847",
+   "metadata": {},
+   "source": [
+    "## All Existing Published Applications"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "532deb27-c43d-4bfe-bdef-f90343d956b1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "15 hosted_workflow_test git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow_test.git\n",
+      "12 hosted_workflow git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow.git\n",
+      "8 test_hosted_workflow_from_python git@dockstore.org:workflows/dockstore.org/mliukis/test_hosted_workflow_from_python.git\n",
+      "5 sounder_sips_l1b git@github.com:nlahaye/sounder-sips-application.git\n",
+      "4 sounder_sips_l1a git@github.com:nlahaye/sounder-sips-application.git\n",
+      "2 sounder_sips_l1b git@github.com:mliukis/sounder-sips-application.git\n",
+      "1 sounder_sips_l1a git@github.com:mliukis/sounder-sips-application.git\n"
+     ]
+    }
+   ],
+   "source": [
+    "for app in app_catalog.application_list(published=True):\n",
     "    print(f\"{app.id} {app.name} {app.source_repository}\")"
    ]
   },
@@ -104,50 +194,17 @@
    "id": "29b1516d-e67e-48d7-a2fc-e4293317f46a",
    "metadata": {},
    "source": [
-    "## New Application"
+    "## Create New Application"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "id": "fcbe7a9c-6893-424d-822a-f1c1a1b10773",
    "metadata": {},
    "outputs": [],
    "source": [
-    "name = \"sounder_sips_l1a\"\n",
-    "source_repository = \"git@github.com:unity-sds/sounder-sips-application.git\"\n",
-    "workflow_path = \"/cwl/l1a_workflow.cwl\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "f2a48297-ca47-43b6-929e-484159876607",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "new_app = ApplicationPackage(name, source_repository, workflow_path)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "eed8a991-dadb-48e9-91b2-fb93abfbf1f8",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "ApplicationPackage(name='sounder_sips_l1a', source_repository='git@github.com:unity-sds/sounder-sips-application.git', workflow_path='/cwl/l1a_workflow.cwl', id=None, is_published=False, description='', workflow_type='CWL')"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "new_app"
+    "name = \"hosted_workflow_by_name\""
    ]
   },
   {
@@ -155,32 +212,63 @@
    "id": "1f94da3e-727a-456e-ab13-32edf688ddba",
    "metadata": {},
    "source": [
-    "## Publish Application"
+    "## Create and Publish New Application in Dockstore"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "f3ea1bb2-00ff-46d6-9a18-ef23a5bd93f0",
+   "cell_type": "markdown",
+   "id": "654b0caf-ca90-46e2-90e4-5dc872db7dcc",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "reg_app = app_catalog.register(new_app)"
+    "### Parameter Files to Upload to Dockstore\n",
+    "\n",
+    "Dockstore hard-codes the path for primary descriptor file of the hosted workflow to **Dockstore.cwl**, so we must use that filename when uploading the file to the Dockstore."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
+   "id": "9b2ea3d8-9dd6-4d42-9346-1e9298d8e2f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "parameter_file_dir = 'data/dockstore_publish'\n",
+    "\n",
+    "cwl_param_files = ['Dockstore.cwl', 'step.cwl']\n",
+    "json_param_files = ['parameters.json']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "f3ea1bb2-00ff-46d6-9a18-ef23a5bd93f0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Publishing the workflow\n"
+     ]
+    }
+   ],
+   "source": [
+    "reg_app = app_catalog.register(name, cwl_files=cwl_param_files, json_files=json_param_files, cwd=parameter_file_dir, publish=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
    "id": "360a929a-bbbf-4a51-8433-b72f7424f7b7",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "DockstoreApplicationPackage(name='sounder_sips_l1a', source_repository='git@github.com:unity-sds/sounder-sips-application.git', workflow_path='/cwl/l1a_workflow.cwl', id='50', is_published=False, description='Processes Sounder SIPS L0 products into L1A products', workflow_type='CWL', dockstore_info={'type': 'BioWorkflow', 'descriptorType': 'CWL', 'aliases': {}, 'author': 'James McDuffie', 'checker_id': None, 'conceptDoi': None, 'dbCreateDate': 1670623272833, 'dbUpdateDate': 1670623276387, 'defaultTestParameterFilePath': '/test.json', 'defaultVersion': 'main', 'description': 'Processes Sounder SIPS L0 products into L1A products', 'descriptorTypeSubclass': 'NOT_APPLICABLE', 'email': 'James.Mcduffie@jpl.nasa.gov', 'forumUrl': None, 'full_workflow_path': 'github.com/unity-sds/sounder-sips-application/sounder_sips_l1a', 'gitUrl': 'git@github.com:unity-sds/sounder-sips-application.git', 'has_checker': False, 'id': 50, 'input_file_formats': [], 'isChecker': False, 'is_published': False, 'labels': [], 'lastUpdated': 1670623272828, 'last_modified': 2004663152, 'last_modified_date': 1668451974000, 'licenseInformation': {'licenseName': 'Other'}, 'mode': 'FULL', 'organization': 'unity-sds', 'output_file_formats': [], 'parent_id': None, 'path': 'github.com/unity-sds/sounder-sips-application', 'repository': 'sounder-sips-application', 'sourceControl': 'github.com', 'source_control_provider': 'GITHUB', 'starredUsers': [], 'topic': 'This repository represents the containerization of the Sounder SIPS SPSS repository into a Unity Application Package.', 'topicAutomatic': 'This repository represents the containerization of the Sounder SIPS SPSS repository into a Unity Application Package.', 'topicId': None, 'topicManual': None, 'topicSelection': 'AUTOMATIC', 'userIdToOrcidPutCode': None, 'users': [{'avatarUrl': 'https://avatars.githubusercontent.com/u/3554574?v=4', 'curator': False, 'id': 2, 'isAdmin': False, 'name': 'mcduffie', 'orcid': None, 'privacyPolicyVersion': 'PRIVACY_POLICY_VERSION_2_5', 'privacyPolicyVersionAcceptanceDate': 1660239673886, 'setupComplete': False, 'tosacceptanceDate': 1660239673886, 'tosversion': 'TOS_VERSION_2', 'userProfiles': None, 'username': 'mcduffie', 'usernameChangeRequired': False}], 'workflowName': 'sounder_sips_l1a', 'workflowVersions': [{'aliases': None, 'author': 'James McDuffie', 'authors': [{'affiliation': None, 'email': 'James.Mcduffie@jpl.nasa.gov', 'name': 'James McDuffie', 'role': None}], 'commitID': 'a1e2cf4b07504820129cd8ed7554134b4534f79d', 'dbUpdateDate': 1670623276387, 'description': 'Processes Sounder SIPS L0 products into L1A products', 'descriptionSource': 'DESCRIPTOR', 'dirtyBit': False, 'doiStatus': 'NOT_REQUESTED', 'doiURL': None, 'email': 'James.Mcduffie@jpl.nasa.gov', 'frozen': False, 'hidden': False, 'id': 73, 'images': None, 'input_file_formats': [], 'last_modified': 1668451974000, 'legacyVersion': True, 'name': 'main', 'orcidAuthors': None, 'output_file_formats': [], 'reference': 'main', 'referenceType': 'BRANCH', 'subClass': None, 'synced': True, 'valid': True, 'validations': None, 'verified': False, 'verifiedSource': None, 'verifiedSources': [], 'versionEditor': None, 'versionMetadata': {'description': 'Processes Sounder SIPS L0 products into L1A products', 'id': 73, 'parsedInformationSet': [{'descriptorLanguage': 'CWL', 'hasHTTPImports': False, 'hasLocalImports': True}], 'publicAccessibleTestParameterFile': None, 'userIdToOrcidPutCode': {}}, 'workflow_path': '/cwl/l1a_workflow.cwl', 'workingDirectory': 'cwl'}], 'workflow_path': '/cwl/l1a_workflow.cwl'})"
+       "DockstoreApplicationPackage(name='hosted_workflow_by_name', source_repository='git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow_by_name.git', workflow_path='/Dockstore.cwl', id='17', is_published=True, description='Bogus hosted workflow registered by unity_py.\\n', workflow_type='CWL', dockstore_info={'type': 'BioWorkflow', 'descriptorType': 'CWL', 'aliases': {}, 'author': 'Masha Liukis', 'checker_id': None, 'conceptDoi': None, 'dbCreateDate': 1681166040783, 'dbUpdateDate': 1681166041216, 'defaultTestParameterFilePath': '/test.json', 'defaultVersion': '1', 'description': 'Bogus hosted workflow registered by unity_py.\\n', 'descriptorTypeSubclass': 'NOT_APPLICABLE', 'email': 'mliukis@jpl.nasa.gov', 'forumUrl': None, 'full_workflow_path': 'dockstore.org/mliukis/hosted_workflow_by_name', 'gitUrl': 'git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow_by_name.git', 'has_checker': False, 'id': 17, 'input_file_formats': [], 'isChecker': False, 'is_published': True, 'labels': [], 'lastUpdated': 1681166040780, 'last_modified': 1833828200, 'last_modified_date': 1681166040936, 'licenseInformation': {'licenseName': None}, 'mode': 'HOSTED', 'organization': 'mliukis', 'output_file_formats': [], 'parent_id': None, 'path': 'dockstore.org/mliukis/hosted_workflow_by_name', 'repository': 'hosted_workflow_by_name', 'sourceControl': 'dockstore.org', 'source_control_provider': 'DOCKSTORE', 'starredUsers': [], 'topic': None, 'topicAutomatic': None, 'topicId': None, 'topicManual': None, 'topicSelection': 'AUTOMATIC', 'userIdToOrcidPutCode': None, 'users': [{'avatarUrl': 'https://avatars.githubusercontent.com/u/72407733?v=4', 'curator': True, 'id': 2, 'isAdmin': True, 'name': 'mliukis', 'orcid': None, 'privacyPolicyVersion': 'PRIVACY_POLICY_VERSION_2_5', 'privacyPolicyVersionAcceptanceDate': 1676409759024, 'setupComplete': False, 'tosacceptanceDate': 1676409759024, 'tosversion': 'TOS_VERSION_2', 'userProfiles': None, 'username': 'mliukis', 'usernameChangeRequired': False}], 'workflowName': None, 'workflowVersions': [{'aliases': None, 'author': 'Masha Liukis', 'authors': [{'affiliation': None, 'email': 'mliukis@jpl.nasa.gov', 'name': 'Masha Liukis', 'role': None}], 'commitID': None, 'dbUpdateDate': 1681166040964, 'description': 'Bogus hosted workflow registered by unity_py.\\n', 'descriptionSource': 'DESCRIPTOR', 'dirtyBit': False, 'doiStatus': 'NOT_REQUESTED', 'doiURL': None, 'email': 'mliukis@jpl.nasa.gov', 'frozen': False, 'hidden': False, 'id': 15, 'images': None, 'input_file_formats': [], 'last_modified': 1681166040936, 'legacyVersion': True, 'name': '1', 'orcidAuthors': None, 'output_file_formats': [], 'reference': None, 'referenceType': 'TAG', 'subClass': None, 'synced': False, 'valid': True, 'validations': None, 'verified': False, 'verifiedSource': None, 'verifiedSources': [], 'versionEditor': {'avatarUrl': 'https://avatars.githubusercontent.com/u/72407733?v=4', 'curator': True, 'id': 2, 'isAdmin': True, 'name': 'mliukis', 'orcid': None, 'privacyPolicyVersion': 'PRIVACY_POLICY_VERSION_2_5', 'privacyPolicyVersionAcceptanceDate': 1676409759024, 'setupComplete': False, 'tosacceptanceDate': 1676409759024, 'tosversion': 'TOS_VERSION_2', 'userProfiles': None, 'username': 'mliukis', 'usernameChangeRequired': False}, 'versionMetadata': {'description': 'Bogus hosted workflow registered by unity_py.\\n', 'id': 15, 'parsedInformationSet': [], 'publicAccessibleTestParameterFile': None, 'userIdToOrcidPutCode': {}}, 'workflow_path': '/Dockstore.cwl', 'workingDirectory': ''}], 'workflow_path': '/Dockstore.cwl'})"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -191,44 +279,238 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e0a1c20b-24b9-406e-9942-31b951a496d7",
+   "metadata": {},
+   "source": [
+    "### Verify Application is Published"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "0313f8f1-90a9-4c1c-b486-17f1d7b3edd9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 sounder_sips_l1a git@github.com:mliukis/sounder-sips-application.git\n",
+      "2 sounder_sips_l1b git@github.com:mliukis/sounder-sips-application.git\n",
+      "8 test_hosted_workflow_from_python git@dockstore.org:workflows/dockstore.org/mliukis/test_hosted_workflow_from_python.git\n",
+      "12 hosted_workflow git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow.git\n",
+      "15 hosted_workflow_test git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow_test.git\n"
+     ]
+    }
+   ],
+   "source": [
+    "for app in app_catalog.application_list(for_user=True, published=True):\n",
+    "    print(f\"{app.id} {app.name} {app.source_repository}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f95baacb-8821-4118-9a67-1789e0cb76a2",
+   "metadata": {},
+   "source": [
+    "## Or Upload Workflow's CWL and JSON Parameters Files One at a Time \n",
+    "\n",
+    "It's possible to upload all parameter files for the workflow at the same time, or upload one parameter file at a time."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9296ea97-a157-47eb-b189-d4ea2886afa5",
+   "metadata": {},
+   "source": [
+    "### Upload Primary Descriptor CWL File for the Application  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9308786c-f5bf-4e9b-b849-c843577bf7bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Remember current path\n",
+    "cwd = os.getcwd()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "dc1d7793-d153-45ca-a247-cc8a78a60ed1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Change directory to where updated files for the upload are\n",
+    "data_dir = 'data/dockstore_update'\n",
+    "os.chdir(data_dir)\n",
+    "\n",
+    "param_file = 'Dockstore.cwl'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "bce63ff3-e76b-4b8d-a3cc-0c8e890bfaab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app_catalog.uploadParameterFile(reg_app, param_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "feefb17e-4fd1-4ee0-bfcd-b2509381de1f",
+   "metadata": {},
+   "source": [
+    "### Upload JSON Parameter File for the Application"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "bb94dd6b-315c-4afb-b5b1-ee4f526a3451",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "json_param_file = 'parameters.json'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "1168e7f6-6cfe-4edb-8b31-8340f875ece4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app_catalog.uploadJSONFile(reg_app, json_param_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38b501b2-eb5f-46e5-96df-9bb0563f440c",
+   "metadata": {},
+   "source": [
+    "### Remove parameter file from the workflow\n",
+    "\n",
+    "To remove any of the uploaded files from the hosted workflow, please upload file with empty contents to the Dockstore."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "b779b2f9-87ab-4643-9843-bda8a9e3937d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file_path = 'step.cwl'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "d01e37fb-a3dd-49d4-b17d-8d576655d58e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app_catalog.uploadParameterFile(reg_app, file_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "704a1308-796f-4591-adf1-a98b35a20b26",
    "metadata": {
     "tags": []
    },
    "source": [
-    "## Delete Application (Cleanup)"
+    "## Unpublish Application\n",
+    "\n",
+    "Dockstore does not allow to delete hosted workflows. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 31,
    "id": "307ee2df-c596-4170-81bb-faff193c86b7",
    "metadata": {},
    "outputs": [],
    "source": [
-    "del_app = app_catalog.unregister(reg_app, delete=True)"
+    "app_catalog.unpublish(reg_app)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08dac163-bc22-4cfd-a853-1a3eaba2e410",
+   "metadata": {},
+   "source": [
+    "## Verify Application Was Unpublished"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "f76c6475-ca8e-46be-bf1e-1608cd628f9d",
+   "execution_count": 34,
+   "id": "978beac7-6dec-4fce-88f4-47f1786c346d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 sounder_sips_l1a git@github.com:mliukis/sounder-sips-application.git\n",
+      "2 sounder_sips_l1b git@github.com:mliukis/sounder-sips-application.git\n",
+      "8 test_hosted_workflow_from_python git@dockstore.org:workflows/dockstore.org/mliukis/test_hosted_workflow_from_python.git\n",
+      "12 hosted_workflow git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow.git\n",
+      "15 hosted_workflow_test git@dockstore.org:workflows/dockstore.org/mliukis/hosted_workflow_test.git\n"
+     ]
+    }
+   ],
+   "source": [
+    "for app in app_catalog.application_list(for_user=True, published=True):\n",
+    "    print(f\"{app.id} {app.name} {app.source_repository}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "12075f02-209d-49d2-b622-f6c65ef8dd8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Change directory back to original\n",
+    "os.chdir(cwd)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "16e49db7-970e-447c-abd0-caa634ddaba6",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "DockstoreApplicationPackage(name='sounder_sips_l1a', source_repository='git@github.com:unity-sds/sounder-sips-application.git', workflow_path='/cwl/l1a_workflow.cwl', id=None, is_published=False, description='Processes Sounder SIPS L0 products into L1A products', workflow_type='CWL', dockstore_info=None)"
+       "'/Users/mliukis/Documents/Unity/ADS/sounder-sips-tutorial/jupyter-notebooks/tutorials'"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "del_app"
+    "os.getcwd()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df8e476f-ad04-456f-ad26-26442d001975",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -247,7 +529,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.9.15"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Purpose
- Demo of unity_py interface to support hosted workflows within Dockstore
## Proposed Changes
- [CHANGE] to use Dockstore hosted workflows
## Testing
- Jupyter notebook demonstrates the use of unity_py interface:
    - to create new application within Dockstore
    - upload CWL and JSON parameter files for the application to the Dockstore
    - upload updated files for the application to the Dockstore
    - upload files for the application with specified Dockstore filepath within the Dockstore
    - remove files from the application in the Dockstore
    - unpublish application within the Dockstore
