### PR TITLE
Updated data notebook to include required urn in collection ID and fix new collection creation

### DIFF
--- a/jupyter-notebooks/tutorials/2_working_with_data.ipynb
+++ b/jupyter-notebooks/tutorials/2_working_with_data.ipynb
@@ -187,7 +187,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_set = \"SNDR_SNPP_ATMS_L1B_OUTPUT___1\"\n",
+    "data_set = \"urn:nasa:unity:uds_local_test:TEST1:SNDR_SNPP_ATMS_L1B_OUTPUT___1\"\n",
     "url = env['url'] + \"am-uds-dapa/collections/\"+data_set+\"/items\"\n",
     "\n",
     "params = []\n",
@@ -232,7 +232,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_set = \"SNDR_SNPP_ATMS_L1B_OUTPUT___1\"\n",
+    "data_set = \"urn:nasa:unity:uds_local_test:TEST1:SNDR_SNPP_ATMS_L1B_OUTPUT___1\"\n",
     "url = env['url'] + \"am-uds-dapa/collections/\"+data_set+\"/items\"\n",
     "# the datetime,limit, and offset are included due to a current bug in the API Gatway setting these values to 'none'.\n",
     "# Example date/time params\n",
@@ -278,7 +278,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "collection_id = \"NEW_COLLECTION_EXAMPLE_L1B___5\"\n",
+    "collection_id = \"urn:nasa:unity:uds_local_test:TEST1:NEW_COLLECTION_EXAMPLE_L1B___5\"\n",
     "collection = {\n",
     "  \"type\": \"Collection\",\n",
     "  \"id\": collection_id,\n",
@@ -315,10 +315,10 @@
     "    \"spatial\": {\n",
     "      \"bbox\": [\n",
     "        [\n",
-    "          -180,\n",
-    "          -90,\n",
-    "          180,\n",
-    "          90\n",
+    "          0,\n",
+    "          0,\n",
+    "          0,\n",
+    "          0\n",
     "        ]\n",
     "      ]\n",
     "    },\n",
@@ -340,7 +340,7 @@
     "      \"(^test_file.*)(\\\\.nc|\\\\.nc\\\\.cas|\\\\.cmr\\\\.xml)\"\n",
     "    ],\n",
     "    \"process\": [\n",
-    "      \"snpp.level1\"\n",
+    "      \"stac\"\n",
     "    ]\n",
     "  }\n",
     "}\n",
@@ -436,7 +436,6 @@
     "import xarray as xr\n",
     "ds = xr.open_dataset('test_file11.nc')\n",
     "ds"
-
    ]
   },
   {


### PR DESCRIPTION
## Purpose
- In helping Alphan troubleshoot the collection he created wasn't available in UDS, we realized the following changes need to be made.
## Proposed Changes
- [CHANGE] Include required urn for collection ID 
- [CHANGE] Change process from snpp.level1 to stac to exercise stac metadata workflow
- [FIX] Collection STAC bounding box for now needs to be 0,0,0,0 (this is fixed by UDS in improved metadata handling in future release)
## Testing
- Alphan successfully created new collection after applying these changes
